### PR TITLE
Add Evaluator.evaluate_constant to read a single constant fact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Add `FactGraph::Evaluator.evaluate_constant(name, graph_class:, module_filter:)` to read a single constant fact's value without building or evaluating the rest of the graph.

--- a/README.md
+++ b/README.md
@@ -242,6 +242,17 @@ When a dependency has errors, the fact is skipped and its result contains:
 
 Use `FactGraph::Evaluator.input_errors(results)` to collect all `fact_bad_inputs` entries from a result set into a single hash.
 
+### Reading a single constant
+
+When you only need the value of a constant (a fact with no inputs or dependencies), `evaluate_constant` returns it without building or evaluating the rest of the graph:
+
+```ruby
+FactGraph::Evaluator.evaluate_constant(:pi)                        # => 3.14
+FactGraph::Evaluator.evaluate_constant(:tax_year, graph_class: Ty2024Graph)  # => 2024
+```
+
+It raises `ArgumentError` if the name is unknown, if the fact has inputs or dependencies (i.e. it isn't a constant), or if the name is ambiguous across modules — pass `module_filter:` to disambiguate.
+
 ## Context-specific graphs
 
 Use `ActiveSupport::Concern` mixins and graph subclasses to compose graphs for different contexts:

--- a/lib/fact_graph/evaluator.rb
+++ b/lib/fact_graph/evaluator.rb
@@ -25,6 +25,26 @@ class FactGraph::Evaluator
       deep_freeze(results)
     end
 
+    # Read a single constant fact's value without building or evaluating the rest of the graph.
+    # A constant is a fact with no inputs and no dependencies (`constant(:name) { value }`).
+    def evaluate_constant(name, graph_class: nil, module_filter: nil)
+      graph_class ||= FactGraph::Graph
+      matches = graph_class.filter_graph(module_filter).select { |fact_kwargs| fact_kwargs[:name] == name }
+
+      raise ArgumentError, "No fact named :#{name}" if matches.empty?
+      if matches.size > 1
+        modules = matches.map { |fact_kwargs| fact_kwargs[:module_name] }
+        raise ArgumentError, "Ambiguous constant :#{name} defined in modules #{modules.inspect}; pass module_filter: to disambiguate"
+      end
+
+      fact = FactGraph::Fact.new(graph: {}, **matches.first)
+      if fact.resolver.respond_to?(:call) || fact.input_definitions.any? || fact.dependencies.any?
+        raise ArgumentError, "Fact :#{fact.module_name}/:#{name} is not a constant (constants take no inputs or dependencies)"
+      end
+
+      fact.resolver
+    end
+
     def key_matches_key_path?(key, key_path)
       return false unless key_path.is_a?(Array) && key_path.count.positive?
 

--- a/spec/fact_graph/evaluator_spec.rb
+++ b/spec/fact_graph/evaluator_spec.rb
@@ -6,6 +6,46 @@ RSpec.describe FactGraph::Evaluator do
     load "spec/fixtures/math.rb"
   end
 
+  describe "#evaluate_constant" do
+    it "returns the value of a constant fact" do
+      expect(described_class.evaluate_constant(:pi)).to eq 3.14
+      expect(described_class.evaluate_constant(:two)).to eq 2
+    end
+
+    it "does not build or evaluate the rest of the graph" do
+      expect(FactGraph::Graph).not_to receive(:prepare_fact_objects)
+      described_class.evaluate_constant(:pi)
+    end
+
+    it "raises when no fact has the given name" do
+      expect { described_class.evaluate_constant(:nope) }
+        .to raise_error(ArgumentError, /No fact named :nope/)
+    end
+
+    it "raises when the fact has inputs or dependencies" do
+      expect { described_class.evaluate_constant(:squared_scale) }
+        .to raise_error(ArgumentError, /is not a constant/)
+    end
+
+    context "when the same constant name exists in multiple modules" do
+      before do
+        Class.new(FactGraph::Graph) do
+          in_module(:other) { constant(:pi) { 3 } }
+        end
+      end
+
+      it "raises unless a module_filter disambiguates" do
+        expect { described_class.evaluate_constant(:pi) }
+          .to raise_error(ArgumentError, /Ambiguous constant :pi/)
+      end
+
+      it "returns the matching module's value when filtered" do
+        expect(described_class.evaluate_constant(:pi, module_filter: [:math_facts])).to eq 3.14
+        expect(described_class.evaluate_constant(:pi, module_filter: [:other])).to eq 3
+      end
+    end
+  end
+
   describe "#key_matches_key_path" do
     context "when passed a key that includes keymaps, hashes and arrays" do
       let(:key) { Dry::Schema::KeyMap["title", "artist", ["tags", ["name"]]] }


### PR DESCRIPTION
## What

Adds `FactGraph::Evaluator.evaluate_constant(name, graph_class:, module_filter:)` — reads a single **constant** fact's value (a fact with no inputs and no dependencies) without building or evaluating the rest of the graph.

```ruby
FactGraph::Evaluator.evaluate_constant(:pi)                                  # => 3.14
FactGraph::Evaluator.evaluate_constant(:tax_year, graph_class: Ty2024Graph)  # => 2024
```

## Why

Today the only way to read a constant is `Evaluator.evaluate(input, module_filter: [...])`, which instantiates and runs every fact in the filtered module(s) — building Dry::Schema validators for facts you don't care about. Downstream apps (e.g. Gyraffe) have per-context constants like `state_code`, `max_age`, `tax_year` defined as `constant(...)` in the graph, but reading them on the request path meant a full filing-context evaluation. This gives a cheap, single-source read so those values don't have to be duplicated as literals in application models.

`evaluate_constant` builds only the single matching `Fact` and returns its `resolver`. It raises `ArgumentError` when:
- no fact has that name,
- the fact has inputs or dependencies (it isn't a constant), or
- the name is ambiguous across modules — pass `module_filter:` to disambiguate.

## Tests

New `#evaluate_constant` specs in `evaluator_spec.rb` cover: reading a constant, not touching `prepare_fact_objects`, unknown name, non-constant (has input), and cross-module ambiguity + `module_filter` disambiguation. Full suite green (62 examples) and RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)